### PR TITLE
Reduce number of RGB<->BGR conversions.

### DIFF
--- a/src/background_selector.cc
+++ b/src/background_selector.cc
@@ -40,7 +40,6 @@ void BackgroundSelector::loadImages() {
             continue;
         }
         cv::resize(img, img, cv::Size(width_, height_));
-        cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 
         auto i = Image{path.filename(), img};
         LOG(INFO) << "Loaded " << i;

--- a/src/main.cc
+++ b/src/main.cc
@@ -77,15 +77,13 @@ int main(int argc, char** argv) {
             break;
         }
 
-        cv::cvtColor(frame, frame, cv::COLOR_BGR2RGB);
         if (do_mask) bgr.maskBackground(frame, bgs.getBackground(), timing);
 
-        wri.writeFrame(frame);
-
         if (debug_flags & DebugFlagShowOutputFrame) {
-            cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
             cv::imshow("frame", frame);
         }
+        cv::cvtColor(frame, frame, cv::COLOR_BGR2RGB);
+        wri.writeFrame(frame);
 
         auto key = cv::waitKey(1);
         switch (key) {


### PR DESCRIPTION
We can keep the loaded background pictures at BGR so we don't have to convert back and forth.